### PR TITLE
Fix invalid linker flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,8 +85,7 @@ if test x"$debugit" = x"yes"; then
 else
     AC_DEFINE([NDEBUG],[],[No-debug Mode])
     AM_CFLAGS="$AM_CFLAGS -Os -ffunction-sections -fdata-sections "
-    AC_SUBST(DBG_LINKOPT," -Wl ")
-    #AM_CPPFLAGS="$AM_CPPFLAGS -Wl --gc-sections "
+    AC_SUBST(DBG_LINKOPT," -Wl,--gc-sections ")
 fi
 
 ##########################################################################


### PR DESCRIPTION
## Summary
- fix broken `-Wl` flag in `configure.ac`

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68424f4a7a08832bb582e5b53c2a93c2